### PR TITLE
feat: Add /deck route to redirect to presentation

### DIFF
--- a/deck/index.html
+++ b/deck/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="refresh" content="0; url=https://docs.google.com/presentation/d/1OkFEQNXDQ5F2feqZN0ayCnjQ4e-uOUHb/edit?slide=id.p1#slide=id.p1">
+  <title>Redirecting...</title>
+</head>
+<body>
+  <p>If you are not redirected automatically, follow this <a href="https://docs.google.com/presentation/d/1OkFEQNXDQ5F2feqZN0ayCnjQ4e-uOUHb/edit?slide=id.p1#slide=id.p1">link to the deck</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
Creates a new route at /deck which redirects to the company's presentation deck on Google Slides.

This is implemented using a client-side meta refresh, which is a standard method for static sites hosted on GitHub Pages.